### PR TITLE
loadstyles is default False, maar de missende styles zorgen mogelijk voor een probleem.

### DIFF
--- a/run.py
+++ b/run.py
@@ -44,7 +44,7 @@ player_options = get_player_list()
 player_tallies = {player: 0 for player in player_options}
 
 # Main loop
-driver = WhatsAPIDriver()
+driver = WhatsAPIDriver(loadstyles=True)
 driver.wait_for_login()
 
 try:


### PR DESCRIPTION
loadstyles is default False. Als loadstyles False is, wordt een niet gestylde versie van webwhatsapp gebruikt. Dit zorgt ervoor dat de verbinding tussen de tool en webwhatsapp niet goed tot stand komt. Als styles geladen worden is dit opgelost.